### PR TITLE
uses new method definition for _.template and logs errors if any

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,10 +35,10 @@
           context = this.getContext(data),
           uris = _.map(templateUris, function(uri){
             try {
-              uri.title = _.template(uri.title, context, templateOptions);
-              uri.url = _.template(uri.url, context, templateOptions);
+              uri.url = _.template(uri.url, templateOptions)(context);
+              uri.title = _.template(uri.title, templateOptions)(context);
             } catch(e) {
-              // do nothing, we'll just return an unmodified version or uri.url
+              console.log('[URL_BUILDER_APP] ' + e);
             }
             return uri;
           }, this);


### PR DESCRIPTION
Since we upgraded to a newer version of Underscore, its `_.template` function no longer accept an initial data object so we need to change this app to use the new definition.

cc @maximeprades