### PR TITLE
interpolate title with the current context

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,7 +11,7 @@
     },
 
     events: {
-      'app.activated'           : 'onAppActivated',
+      'app.created'             : 'onAppCreated',
       '*.changed'               : function(e) {
         if (_.contains(this.fieldsToWatch(), e.propertyName))
           return this.onAppActivated();
@@ -19,7 +19,7 @@
       'fetchUsers.done' : 'onFetchUsersDone'
     },
 
-    onAppActivated: function() {
+    onAppCreated: function() {
       var userIds = _.compact(_.uniq([
         (this.ticket().assignee().user() && this.ticket().assignee().user().id()),
         this.currentUser().id(),
@@ -31,10 +31,12 @@
 
     onFetchUsersDone: function(data) {
       var templateUris = this.getUriTemplatesFromSettings(),
+          templateOptions = { interpolate : /\{\{(.+?)\}\}/g },
           context = this.getContext(data),
           uris = _.map(templateUris, function(uri){
             try {
-              uri.url = _.template(uri.url, context, { interpolate : /\{\{(.+?)\}\}/g });
+              uri.title = _.template(uri.title, context, templateOptions);
+              uri.url = _.template(uri.url, context, templateOptions);
             } catch(e) {
               // do nothing, we'll just return an unmodified version or uri.url
             }


### PR DESCRIPTION
### Feature

* **Interpolates the title as well as the url. You can now use variables in the button title**

For the given json configuration:
```json
[
  {
    "title": "First Title {{ticket.requester.name}}",
    "url": "http://example.com/?name={{ticket.requester.name}}"
  },
  {
    "title": "Second Title (with custom field)",
    "url": "http://example.com/?custom={{ticket.custom_field_424242}}"
  }
]
```

Output used to be:
![screen shot 2015-04-07 at 16 01 37](https://cloud.githubusercontent.com/assets/330573/7026138/f1f6de6c-dd3f-11e4-8495-fa59690f55e8.png)

Will now be:
![screen shot 2015-04-07 at 15 58 48](https://cloud.githubusercontent.com/assets/330573/7026146/f7b08ab0-dd3f-11e4-8d06-4c1ba1e7da69.png)

### Bugfix
* Uses `app.created` instead of `app.activated`

fixes https://github.com/zendesklabs/url_builder_app/issues/6 https://github.com/zendesklabs/url_builder_app/issues/5