### PR TITLE
Update instruction view

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,31 +48,31 @@ This example will generate the following HTML inside the app:
 ```
 
 ### Available Placeholders
-* {{ticket.id}} //not available for new tickets
-* {{ticket.description}}
-* {{ticket.requester.id}}
-* {{ticket.requester.name}}
-* {{ticket.requester.email}}
-* {{ticket.requester.externalId}}
-* {{ticket.requester.firstname}}
-* {{ticket.requester.lastname}}
-* {{ticket.requester.user_fields.YYY}} = custom user fields can be used
-* {{ticket.assignee.user.id}}
-* {{ticket.assignee.user.name}}
-* {{ticket.assignee.user.email}}
-* {{ticket.assignee.user.externalId}}
-* {{ticket.assignee.user.firstname}}
-* {{ticket.assignee.user.lastname}}
-* {{ticket.assignee.group.id}}
-* {{ticket.assignee.group.name}}
-* {{ticket.custom_field_XXXXXXX}} // XXXXXXX = custom field id
-* {{ticket.organization.organization_fields.XXXXXXX}} // XXXXXXX = Field key, default is field name
-* {{current_user.id}}
-* {{current_user.name}}
-* {{current_user.email}}
-* {{current_user.externalId}}
-* {{current_user.firstname}}
-* {{current_user.lastname}}
+* `{{ticket.id}}` //not available for new tickets
+* `{{ticket.description}}`
+* `{{ticket.requester.id}}`
+* `{{ticket.requester.name}}`
+* `{{ticket.requester.email}}`
+* `{{ticket.requester.externalId}}`
+* `{{ticket.requester.firstname}}`
+* `{{ticket.requester.lastname}}`
+* `{{ticket.requester.user_fields.YYY}}` = custom user fields can be used
+* `{{ticket.assignee.user.id}}`
+* `{{ticket.assignee.user.name}}`
+* `{{ticket.assignee.user.email}}`
+* `{{ticket.assignee.user.externalId}}`
+* `{{ticket.assignee.user.firstname}}`
+* `{{ticket.assignee.user.lastname}}`
+* `{{ticket.assignee.group.id}}`
+* `{{ticket.assignee.group.name}}`
+* `{{ticket.custom_field_XXXXXXX}}` // XXXXXXX = custom field id
+* `{{ticket.organization.organization_fields.XXXXXXX}}` // XXXXXXX = Field key, default is field name
+* `{{current_user.id}}`
+* `{{current_user.name}}`
+* `{{current_user.email}}`
+* `{{current_user.externalId}}`
+* `{{current_user.firstname}}`
+* `{{current_user.lastname}}`
 
 ### Making changes
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This example will generate the following HTML inside the app:
 
 If you wish to change the output, locate the app by looking for the name you choose in step 4 above. Use the widget to `Change Settings`
 
-<img width="195" src="https://github.com/watchmanmonitoring/url_builder_app/raw/master/assets/app-settings-change.png" />
+<img width="195" src="/assets/app-settings-change.png" />
 
 
 ## Contribution


### PR DESCRIPTION
I noticed that, in the public version of this app, the screenshot was referenced from our repo, and that none of the samples showed through

I can't test the public view well, but assume that backticks around the `{{` will help.
