### PR TITLE
fixing broken image references

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Description:
 
-A Zendesk App to help you generate links for agents.
+A Zendesk App to help you generate useful links for Agents.
 
 ## Instructions:
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This example will generate the following HTML inside the app:
 
 If you wish to change the output, locate the app by looking for the name you choose in step 4 above. Use the widget to `Change Settings`
 
-<img width="195" src="https://github.com/watchmanmonitoring/url_builder_app/raw/master/assets/app-settings-change.png" />
+<img width="195" src="https://raw.githubusercontent.com/zendesklabs/url_builder_app/master/assets/app-settings-change.png" />
 
 
 ## Contribution
@@ -86,4 +86,4 @@ If you wish to change the output, locate the app by looking for the name you cho
 Improvements are always welcome. To contribute, please submit detailed Pull Requests.
 
 ## Screenshot(s):
-![screenshot-1](/assets/screenshot.png)
+<img width="600" src="https://raw.githubusercontent.com/zendesklabs/url_builder_app/master/assets/screenshot.png" />


### PR DESCRIPTION
Currently, the image resource on zendesk.com refers back to our branch:

https://www.zendesk.com/apps/url-builder/

![screenshot_2145](https://cloud.githubusercontent.com/assets/2879972/19438966/ddcaf684-9441-11e6-9950-b2f22c738de5.png)

I don't know that this will fix that, but at least the broken will point back to master.
